### PR TITLE
feat: (💡) delaying initial service tick

### DIFF
--- a/src/CronTool/CronTool.csproj
+++ b/src/CronTool/CronTool.csproj
@@ -16,7 +16,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/rniemand/cron-tool</RepositoryUrl>
     <AssemblyName>Rn.CronTool</AssemblyName>
-    <Version>1.0.5.102</Version>
+    <Version>1.0.5.103</Version>
     <PackageTags>cron</PackageTags>
   </PropertyGroup>
 

--- a/src/CronTools.Common/Services/CronToolRunnerService.cs
+++ b/src/CronTools.Common/Services/CronToolRunnerService.cs
@@ -27,6 +27,7 @@ public class CronToolRunnerService : ICronToolRunnerService
   private readonly IJobSchedulerService _schedulerService;
   private List<JobConfig> _enabledJobs;
   private DateTime _nextJobRefresh;
+  private bool _firstTick = true;
 
   public CronToolRunnerService(
     ILoggerAdapter<CronToolRunnerService> logger,
@@ -51,6 +52,21 @@ public class CronToolRunnerService : ICronToolRunnerService
   public async Task TickAsync(CancellationToken stoppingToken)
   {
     // TODO: [CronToolRunnerService.TickAsync] (TESTS) Add tests
+    // Ignore the first tick to allow the service to start up when running as a service
+    // as there may bo jobs queued that take a while to execute
+    if (_firstTick)
+    {
+      _firstTick = false;
+      return;
+    }
+
+    await DiscoverAndRunJobsAsync(stoppingToken);
+  }
+
+  // Working with scheduled jobs
+  private async Task DiscoverAndRunJobsAsync(CancellationToken stoppingToken)
+  {
+    // TODO: [CronToolRunnerService.DiscoverAndRunJobsAsync] (TESTS) Add tests
     RefreshJobs();
 
     // Check to see if there are any jobs that need to run now
@@ -78,7 +94,6 @@ public class CronToolRunnerService : ICronToolRunnerService
     _scheduleProvider.SaveSchedule(_scheduledJobs);
   }
 
-  // Working with scheduled jobs
   private void RefreshJobs()
   {
     // TODO: [CronToolRunnerService.RefreshJobs] (TESTS) Add tests

--- a/src/DevConsole/Program.cs
+++ b/src/DevConsole/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.DependencyInjection;
 //  .GetRequiredService<IJobRunnerService>()
 //  .RunJobAsync("ScheduledJob");
 
-await CronToolDIContainer.ServiceProvider
-  .GetRequiredService<ICronToolRunnerService>()
-  .TickAsync(CancellationToken.None);
+var service = CronToolDIContainer.ServiceProvider
+  .GetRequiredService<ICronToolRunnerService>();
+
+await service.TickAsync(CancellationToken.None); // Sets "_firstTick" to FALSE
+await service.TickAsync(CancellationToken.None); // Runs scheduled jobs

--- a/src/DevConsole/Program.cs
+++ b/src/DevConsole/Program.cs
@@ -2,12 +2,10 @@ using CronTools.Common.Services;
 using CronTools.Common.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
-//await CronToolDIContainer.ServiceProvider
-//  .GetRequiredService<IJobRunnerService>()
-//  .RunJobAsync("ScheduledJob");
+await CronToolDIContainer.ServiceProvider
+  .GetRequiredService<IJobRunnerService>()
+  .RunJobAsync("ScheduledJob");
 
-var service = CronToolDIContainer.ServiceProvider
-  .GetRequiredService<ICronToolRunnerService>();
-
-await service.TickAsync(CancellationToken.None); // Sets "_firstTick" to FALSE
-await service.TickAsync(CancellationToken.None); // Runs scheduled jobs
+//var service = CronToolDIContainer.ServiceProvider.GetRequiredService<ICronToolRunnerService>();
+//await service.TickAsync(CancellationToken.None); // Sets "_firstTick" to FALSE
+//await service.TickAsync(CancellationToken.None); // Runs scheduled jobs


### PR DESCRIPTION
# PR: Information
Added logic to delay the initial service tick to allow for container to settle.

## PR Checklist
I have preformed the following actions for this commit:

- [x] Updated version for `src/CronTool/CronTool.csproj`
- [x] Added in **documentation** for this feature
- [x] I have performed a self-review of my own code
- [x] I have commented my changes in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The project is building locally
- [x] Supporting tests have been added for my change